### PR TITLE
MPD albumart support. Major update of album_art.py. Candidate for UAT

### DIFF
--- a/mopidy_mpd/protocol/album_art.py
+++ b/mopidy_mpd/protocol/album_art.py
@@ -1,58 +1,76 @@
+import logging
 from mopidy_mpd import protocol
 from urllib.request import urlopen
 
-
-def _get_art_url(self, track):
-    images = self.core.library.get_images([track.uri]).get()
-    if images[track.uri]:
-        largest_image = sorted(
-            images[track.uri], key=lambda i: i.width or 0, reverse=True
-        )[0]
-        return largest_image.uri
-
+logger = logging.getLogger(__name__)
 
 cover_cache = {}
 
+def _get_art_uri(context, uri):
+    image_uri = ''
+    images = context.core.library.get_images([uri]).get()
+    if images:
+        if images[uri]:
+            #To do: implement user config parameter for image size preference
+            #For now return smallest image to limit wireless download size
+            image_uri = sorted(
+                images[uri], key=lambda i: i.width or 0, reverse=False
+            )[0].uri
+            logger.debug("Found image uri: %s", str(image_uri))
+    return image_uri
+
+def _search_uri(context, uri):
+    album_uri = ''
+    uriList = context.core.library.search({'uri': [uri]}).get()
+    if uriList:
+        album_uri = str(uriList[0].tracks[0].album.uri)
+        logger.debug("Found album uri: %s", str(album_uri))
+        # Note an album uri is encrypted and MD5 hashed
+    return album_uri
 
 @protocol.commands.add("albumart")
 def albumart(context, uri, offset):
     """
     *musicpd.org, the music database section:*
-
         ``albumart {URI} {OFFSET}``
-
         Locate album art for the given song and return a chunk
         of an album art image file at offset OFFSET.
-
         This is currently implemented by searching the directory
         the file resides in for a file called cover.png, cover.jpg,
         cover.tiff or cover.bmp.
-
         Returns the file size and actual number of bytes read at
         the requested offset, followed by the chunk requested as
         raw bytes (see Binary Responses), then a newline and the completion code.
-
         Example::
-
             albumart foo/bar.ogg 0
             size: 1024768
             binary: 8192
             <8192 bytes>
             OK
-
     .. versionadded:: 0.21
         New in MPD protocol version 0.21
     """
     global cover_cache
+    art_uri = ''
+
+    logger.debug("Album art request for uri: %s", str(uri)) 
 
     if uri not in cover_cache:
-        (tlid, track) = context.core.playback.get_current_tl_track().get()
-        art_url = _get_art_url(context, track)
+        art_uri = _get_art_uri(context ,uri)   
+        if not art_uri:
+            # Attempt to find art via a library uri search
+            # Applicable when an MPD client supplies only the album part of a uri
+            album_uri = _search_uri(context, uri)
+            if album_uri:
+                art_uri = _get_art_uri(context, album_uri)
+            if not art_uri:
+                return b"binary: 0\n"
 
-        if art_url is None:
-            return b"binary: 0\n"
-
-        cover_cache[uri] = urlopen(art_url).read()
+        art_uri = art_uri.replace("/local/", "file:///media/Data1/Mopidy/Data/local/images/", 1) 
+       
+        logger.info("Open image uri: %s", str(art_uri))
+            
+        cover_cache[uri] = urlopen(art_uri).read()
 
     data = cover_cache[uri]
 
@@ -71,37 +89,28 @@ def albumart(context, uri, offset):
         data[offset : offset + size],
     )
 
-
 # @protocol.commands.add("readpicture") # not yet implemented
 def readpicture(context, uri, offset):
     """
     *musicpd.org, the music database section:*
-
         ``readpicture {URI} {OFFSET}``
-
         Locate a picture for the given song and return a chunk
         of the image file at offset OFFSET. This is usually
         implemented by reading embedded pictures from
         binary tags (e.g. ID3v2's APIC tag).
-
         Returns the following values:
-
         * size: the total file size
         * type: the file's MIME type (optional)
         * binary: see Binary Responses
-
         If the song file was recognized, but there is no picture,
         the response is successful, but is otherwise empty.
-
         Example::
-
             readpicture foo/bar.ogg 0
             size: 1024768
             type: image/jpeg
             binary: 8192
             <8192 bytes>
             OK
-
     .. versionadded:: 0.21
         New in MPD protocol version 0.21
     """

--- a/mopidy_mpd/protocol/album_art.py
+++ b/mopidy_mpd/protocol/album_art.py
@@ -20,8 +20,6 @@ class _config:
         
         _config.image_dir = local_ext.get_image_dir(_config.config)
         logger.debug("Local image directory: %s", str(_config.image_dir))
-        
-        logger.info("Test config: " + str(_config.config["mpd"]["port"]))
 
 def _get_art_uri(context, uri):
     # Get art uri from backend libraries

--- a/mopidy_mpd/protocol/album_art.py
+++ b/mopidy_mpd/protocol/album_art.py
@@ -1,32 +1,70 @@
 import logging
 from mopidy_mpd import protocol
 from urllib.request import urlopen
+import uritools
+import pathlib
 
 logger = logging.getLogger(__name__)
 
 cover_cache = {}
 
+
 def _get_art_uri(context, uri):
-    image_uri = ''
+    # Get art uri from backend libraries
+    # Note: for mopidy_local extension images configuration parameter
+    # local/album_art_files determines which images are made available
+
+    image_uri = ""
+
     images = context.core.library.get_images([uri]).get()
+
     if images:
         if images[uri]:
-            #To do: implement user config parameter for image size preference
-            #For now return smallest image to limit wireless download size
-            image_uri = sorted(
+            # Select smallest image with a minium width of 600px to limit
+            # download and client cache size.
+            # If no image with min. width exists use largest available.
+            # To do: implement user config parameter for image size preference
+            images_sorted = sorted(
                 images[uri], key=lambda i: i.width or 0, reverse=False
-            )[0].uri
-            logger.debug("Found image uri: %s", str(image_uri))
+            )
+            for i in images_sorted:
+                if i.width > 599:
+                    image_uri = i.uri
+                    break
+            if not image_uri:
+                image_uri = images_sorted[-1].uri
+
+            logger.debug("Found image uri in library: %s", str(image_uri))
     return image_uri
 
+
 def _search_uri(context, uri):
-    album_uri = ''
-    uriList = context.core.library.search({'uri': [uri]}).get()
-    if uriList:
-        album_uri = str(uriList[0].tracks[0].album.uri)
-        logger.debug("Found album uri: %s", str(album_uri))
+    # Request image uri from backend libraries
+
+    album_uri = ""
+
+    resultList = context.core.library.search({"uri": [uri]}).get()
+    if resultList[0].tracks:
+        album_uri = str(resultList[0].tracks[0].album.uri)
+        logger.debug("Found album uri in library: %s", str(album_uri))
         # Note an album uri is encrypted and MD5 hashed
     return album_uri
+
+
+def _get_local_art_uri(context, uri):
+    # Translate local extension image uri value to absolute file path
+    
+    from mopidy_local import Extension as local_ext
+
+    art_uri = ""
+
+    image_dir = local_ext.get_image_dir(context.dispatcher.config)
+    logger.debug("Local image directory: %s", str(image_dir))
+
+    art_uri = pathlib.PurePath(image_dir).joinpath(pathlib.PurePath(uri).name).as_uri()
+    logger.debug("Local art filename: %s", str(art_uri))
+    return art_uri
+
 
 @protocol.commands.add("albumart")
 def albumart(context, uri, offset):
@@ -48,29 +86,49 @@ def albumart(context, uri, offset):
             <8192 bytes>
             OK
     .. versionadded:: 0.21
-        New in MPD protocol version 0.21
+        New in MPD protocol version 0.21.0
+        Major improvement in MPD  protocol version 0.21.11
     """
-    global cover_cache
-    art_uri = ''
 
-    logger.debug("Album art request for uri: %s", str(uri)) 
+    global cover_cache
+    art_uri = ""
+
+    logger.debug("Album art request for uri: %s", str(uri))
+
+    if not uritools.isuri(uri):
+        logger.debug("Not a valid uri: %s", str(uri))
+        return b"binary: 0\n"
 
     if uri not in cover_cache:
-        art_uri = _get_art_uri(context ,uri)   
+        art_uri = _get_art_uri(context, uri)
         if not art_uri:
             # Attempt to find art via a library uri search
             # Applicable when an MPD client supplies only the album part of a uri
+
             album_uri = _search_uri(context, uri)
+            
             if album_uri:
                 art_uri = _get_art_uri(context, album_uri)
             if not art_uri:
-                return b"binary: 0\n"
+                uri_scheme = uritools.urisplit(uri).scheme
+                if uri_scheme == "http" or uri_scheme == "https":
+                    # As a last resort, allow external web searches (incl. internet)
 
-        art_uri = art_uri.replace("/local/", "file:///media/Data1/Mopidy/Data/local/images/", 1) 
-       
-        logger.info("Open image uri: %s", str(art_uri))
-            
-        cover_cache[uri] = urlopen(art_uri).read()
+                    art_uri = uri
+                else:
+                    logger.debug("Can't find album art for uri: %s", str(uri))
+                    return b"binary: 0\n"
+
+        if art_uri.find("local", 1, 7) != -1:
+            # For images obtained from local backend translate file path to uri
+
+            art_uri = _get_local_art_uri(context, art_uri)
+
+        try:
+            cover_cache[uri] = urlopen(art_uri).read()
+        except:
+            logger.debug("Can't open uri: %s", art_uri)
+            return b"binary: 0\n"
 
     data = cover_cache[uri]
 
@@ -88,6 +146,7 @@ def albumart(context, uri, offset):
         size,
         data[offset : offset + size],
     )
+
 
 # @protocol.commands.add("readpicture") # not yet implemented
 def readpicture(context, uri, offset):


### PR DESCRIPTION
Implements MPD albumart command retrieval of image from mopidy_local extension. Also supports albumart request of  images via HTTP(S).
Extended debugging and exception handling.

Verified to work with:
- MAFA Android MPD client
- MPDCtrl and Stylophone Windows MPD clients (note these clients have other issues with Mopidy's MPD implementation)
- Home Automation server web GUI and mobile app.
- (Also tested some other clients that don't support MPD albumart to assure they don't brake).
